### PR TITLE
Add dynamic lookup for ip address of current system

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,8 @@ use Mix.Config
 # if you want to provide default values for your application for
 # 3rd-party users, it should be done in your "mix.exs" file.
 
-config :sonex, [{:dlna_listen_addr, {192,168,0,118}}]
+{:ok, [{ip_addr,_,_},_]} = :inet.getif()
+config :sonex, [{:dlna_listen_addr, ip_addr}]
 
 # You can configure for your application as:
 #


### PR DESCRIPTION
Currently the `dlna_listen_addr` is hard-coded to `{192,168,0,118}`. I changed this to a dynamic lookup with `:net.getif()`.

I'm just started learning Elixir so all feedback is welcome!
